### PR TITLE
Fix text encoding for ArcGIS Pro

### DIFF
--- a/OptimizeRasters.py
+++ b/OptimizeRasters.py
@@ -2792,7 +2792,7 @@ class S3Storage:
         urlResponse = None
         try:
             urlResponse = urlopen(roleMetaUrl)
-            IamRole = urlResponse.read()
+            IamRole = urlResponse.read().decode('utf-8')
             if (IamRole.find('404') != -1):
                 return None
             urlResponse.close()


### PR DESCRIPTION
In the latest release, accessing an S3 IAM role fails in ArcGIS pro due to a binary string not working in a string substitution. This is a one line fix for that case. It appears to be an issue only for Pro/Python 3, not for ArcMap-based UI.

Before:
![image](https://user-images.githubusercontent.com/1691225/47669440-8b054a80-db70-11e8-9b7d-5d567d5e94a4.png)

After: 

![image](https://user-images.githubusercontent.com/1691225/47669464-9193c200-db70-11e8-8b7c-ef1348c45a8c.png)
