### PR TITLE
Saijin naib pyt label patch

### DIFF
--- a/OptimizeRasters.pyt
+++ b/OptimizeRasters.pyt
@@ -322,8 +322,8 @@ class Toolbox(object):
     def __init__(self):
         """Define the toolbox (the name of the toolbox is the name of the
         .pyt file)."""
-        self.label = "Toolbox"
-        self.alias = ""
+        self.label = "OptimizeRasters"
+        self.alias = "Optimize Rasters"
         # List of tool classes associated with this toolbox
         self.tools = [OptimizeRasters, ProfileEditor, ResumeJobs]
 

--- a/OptimizeRasters.pyt
+++ b/OptimizeRasters.pyt
@@ -322,7 +322,7 @@ class Toolbox(object):
     def __init__(self):
         """Define the toolbox (the name of the toolbox is the name of the
         .pyt file)."""
-        self.label = "OptimizeRasters"
+        self.label = "Optimize Rasters"
         self.alias = "Optimize Rasters"
         # List of tool classes associated with this toolbox
         self.tools = [OptimizeRasters, ProfileEditor, ResumeJobs]

--- a/OptimizeRasters.pyt
+++ b/OptimizeRasters.pyt
@@ -322,8 +322,8 @@ class Toolbox(object):
     def __init__(self):
         """Define the toolbox (the name of the toolbox is the name of the
         .pyt file)."""
-        self.label = "Optimize Rasters"
-        self.alias = "Optimize Rasters"
+        self.label = "OptimizeRasters"
+        self.alias = "OptimizeRasters"
         # List of tool classes associated with this toolbox
         self.tools = [OptimizeRasters, ProfileEditor, ResumeJobs]
 


### PR DESCRIPTION
Quite simply, I dislike this toolbox showing up in the ArcToolbox window as "Toolbox". That is not a great UI/UX.

I've renamed it to Optimize Rasters to be consistent with the internal naming of the tool, and to ensure it is easily visible in the ArcToolbox window.