### PR TITLE
S3 Files >2GB Cause OverflowError Due to SSL

### DIFF
--- a/OptimizeRasters.py
+++ b/OptimizeRasters.py
@@ -6874,7 +6874,9 @@ class Application(object):
                             if (cloudDownloadType == Store.TypeAmazon):
                                     if (self._base.getBooleanValue(self._base.getUserConfiguration.getValue(UseToken))):
                                         resp = o_S3_storage.con.meta.client.get_object(Bucket=o_S3_storage.m_bucketname, Key=preAkey) # , Range='bytes={}-{}'.format(0, 4))
-                                        self._args.preFetchedMRF = resp['Body'].read()
+                                        self._args.preFetchedMRF = b''
+                                        for chunk in resp['Body'].iter_chunks(chunk_size=1024**3):
+                                            self._args.preFetchedMRF += chunk
                                     else:
                                         self._args.preAssignedURL = o_S3_storage.con.meta.client.generate_presigned_url(
                                             'get_object', Params={'Bucket': o_S3_storage.m_bucketname, 'Key': preAkey})


### PR DESCRIPTION
In python versions earlier than 3.10 the standard OpenSSL library version used only supported 32-bit reads. The result of this is that when trying to use OptimizeRasters on an S3 file that is > 2GB it fails with a non-intuitive error "signed integer greater than maximum value". The proposed code limits the amount of data that will be read in a single shot from S3 to avoid this issue. I have tested and verified this code against an image greater than 2GB.